### PR TITLE
refactor: @types/css-modules로  css type을 정의한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
+    "@types/css-modules": "^1.0.2",
     "@types/react": "^17.0.11",
     "@types/react-dom": "^17.0.7",
     "@typescript-eslint/eslint-plugin": "^4.26.1",

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -1,5 +1,0 @@
-declare module "*.module.scss" {
-  const styles: { [className: string]: string };
-
-  export default styles;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@types/css-modules@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/css-modules/-/css-modules-1.0.2.tgz#8884135f9be3e204b42ef7ad7fce2474e8d74cb6"
+  integrity sha512-tyqlt2GtEBdsxJylh78zSxI/kOJK5Iz8Ta4Fxr8KLTP8mD/IgMa84D8EKPS/AWCp+MDoctgJyikrVWY28GKmcg==
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz"


### PR DESCRIPTION
type.d.ts 에 custom 으로 CSSModules 의 type을 정의하던 것을 @types/css-modules 로 대체하였습니다.

**관련 Reference**
- https://reactjs.org/docs/static-type-checking.html#type-definitions
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f7ec78508c6797e42f87a4390735bc2c650a1bfd/types/css-modules/index.d.ts